### PR TITLE
Document 'g:flow#omnifunc' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ a custom flow executable, set this like so:
 let g:flow#flowpath = /your/flow-path/flow
 ```
 
+#### `g:flow#omnifunc`
+
+By default `omnifunc` will be set to provide omni completion. To disable it
+(prevent overwriting an existed omnifunc), set this value to 0:
+
+```VimL
+let g:flow#omnifunc = 0
+```
+
 #### `g:flow#qfsize`
 
 Leave this as default to let the plugin decide on the quickfix window size.

--- a/doc/vim-flow.txt
+++ b/doc/vim-flow.txt
@@ -38,6 +38,13 @@ a custom flow executable, set this like so:
 
 let g:flow#flowpath = /your/flow-path/flow
 
+g:flow#omnifunc                                                 *g:flow#omnifunc*
+
+By default 'omnifunc' will be set to provide omni completion. To disable it
+(prevent overwriting an existed omnifunc), set this value to 0:
+
+let g:flow#omnifunc = 0
+
 g:flow#qfsize                                                     *g:flow#qfsize*
 
 Leave this as default to let the plugin decide on the |quickfix| window size.


### PR DESCRIPTION
HI,

Thank you for such a useful plugin!

Though I found a undocumented variable `g:flow#omnifunc`, which has a similar format to other options, can toggle the omnicompletion. I'm not sure if it is hidden from public on purpose, but I think it's useful for a user who only need type checking. So I add a phrase in document about this option.